### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/adapton/adapton.scrbl
+++ b/adapton/adapton.scrbl
@@ -10,7 +10,7 @@
      (evaluator '(require "main.rkt"))
      evaluator))
 
-@title[#:tag "top"]{@bold{Adapton}: Composable, Demand-Driven Incremental Computation}
+@title[#:tag "top"]{Adapton: Composable, Demand-Driven Incremental Computation}
 
 by Clayton Mentzer and Matt Hammer cmentzer at ccs dot neu dot edu
 


### PR DESCRIPTION
For visual consistency with other packages within the docs